### PR TITLE
Correct the path to the .env file so you can run the app from within example dirs

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,9 @@
 var express = require('express');
 var exphbs = require('express-handlebars');
 
-require('dotenv').config();
+require('dotenv').config({
+	path: __dirname + '/.env'
+});
 
 /* create a new express app each time so the routes are distinct in the tests */
 function createApp () {


### PR DESCRIPTION
The default path for the `.env` file is a relative path so if you were inside an example directory and ran the app from there then no `.env` file could be found.

This PR changes the path to an absolute path.

**Before**
```bash
⚡  node oauth/index.js 
visit http://localhost:3000 to start the OAuth flow
^C
⚡  cd oauth/
⚡  node index.js
{ [Error: ENOENT: no such file or directory, open '.env'] errno: -2, code: 'ENOENT', syscall: 'open', path: '.env' }
visit http://localhost:3000 to start the OAuth flow
^C

```

**After**
```bash
⚡  node oauth/index.js 
visit http://localhost:3000 to start the OAuth flow
^C
⚡  cd oauth/
⚡  node index.js 
visit http://localhost:3000 to start the OAuth flow
^C
```
